### PR TITLE
Allow for complex types and collections to be used as [Property]s.

### DIFF
--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -239,7 +239,7 @@ namespace RedArrow.Argo.Client.Session
                 && resource.Attributes != null
                 && resource.Attributes.TryGetValue(attrName, out jValue))
             {
-                return jValue.Value<TAttr>();
+                return jValue.ToObject<TAttr>();
             }
             return default(TAttr);
         }

--- a/src/WovenByFody/ObjectWithCollectionsAndComplexTypesAsProperties.cs
+++ b/src/WovenByFody/ObjectWithCollectionsAndComplexTypesAsProperties.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using RedArrow.Argo.Attributes;
+
+namespace WovenByFody
+{
+
+    public class InnerObject
+    {
+        public string Value { get; set; }
+    }
+
+    [Model("test-property-collection")]
+    public class ObjectWithCollectionsAndComplexTypesAsProperties
+    {
+        [Id]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Tests storing a collection as a Property, rather than HasMany
+        /// </summary>
+        [Property]
+        public ICollection<InnerObject> TestingDescriptions { get; set; }
+
+        /// <summary>
+        /// Tests storing a complext type as a Property, rather than HasOne
+        /// </summary>
+        [Property]
+        public InnerObject TestingDescription { get; set; }
+    }
+}

--- a/src/WovenByFody/WovenByFody.projitems
+++ b/src/WovenByFody/WovenByFody.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AllPropertyTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IdPropertyTestModels.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ObjectWithCollectionsAndComplexTypesAsProperties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Provider.cs" />
   </ItemGroup>


### PR DESCRIPTION
A small change to use jValue.ToObject<TAttr> instead of jValue.Value<TAttr> in GetAttribute. 