### PR TITLE
updates session to handle ok responses that MUST contain updated resource per spec

### DIFF
--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -157,6 +157,12 @@ namespace RedArrow.Argo.Client.Session
             var request = HttpRequestBuilder.UpdateResource(patch, includes);
             var response = await HttpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var root = await response.GetContentModel<ResourceRootSingle>(JsonSettings);
+                var m = CreateResourceModel(root.Data);
+                Cache.Update(root.Data.Id, m);
+            }
 
             // create and cache includes
             await Task.WhenAll(includes.Select(x => Task.Run(() =>

--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -157,11 +157,15 @@ namespace RedArrow.Argo.Client.Session
             var request = HttpRequestBuilder.UpdateResource(patch, includes);
             var response = await HttpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
+
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var root = await response.GetContentModel<ResourceRootSingle>(JsonSettings);
-                var m = CreateResourceModel(root.Data);
-                Cache.Update(root.Data.Id, m);
+                if (root.Data != null)
+                {
+                    var m = CreateResourceModel(root.Data);
+                    Cache.Update(root.Data.Id, m);
+                }
             }
 
             // create and cache includes

--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -167,6 +167,10 @@ namespace RedArrow.Argo.Client.Session
                     Cache.Update(root.Data.Id, m);
                 }
             }
+            else if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                ModelRegistry.ApplyPatch(model);
+            }
 
             // create and cache includes
             await Task.WhenAll(includes.Select(x => Task.Run(() =>
@@ -174,8 +178,6 @@ namespace RedArrow.Argo.Client.Session
                 var m = CreateResourceModel(x);
                 Cache.Update(x.Id, m);
             })));
-
-            ModelRegistry.ApplyPatch(model);
         }
 
         public async Task<TModel> Get<TModel>(Guid id)


### PR DESCRIPTION
200 OK

If a server accepts an update but also changes the resource(s) in ways other than those specified by the request (for example, updating the updated-at attribute or a computed sha), it MUST return a 200 OK response. The response document MUST include a representation of the updated resource(s) as if a GET request was made to the request URL.