### PR TITLE
Revert "update to accept where queryable to use "and" "or""

### DIFF
--- a/src/RedArrow.Argo.Client/Linq/Queryables/WhereQueryable.cs
+++ b/src/RedArrow.Argo.Client/Linq/Queryables/WhereQueryable.cs
@@ -187,12 +187,12 @@ namespace RedArrow.Argo.Client.Linq.Queryables
             var bExpression = expression as BinaryExpression;
             if (bExpression == null) throw new NotSupportedException();
 
-            if (bExpression.NodeType == ExpressionType.AndAlso || bExpression.NodeType == ExpressionType.And)
+            if (bExpression.NodeType == ExpressionType.AndAlso)
             {
                 return $"({TranslateExpression(bExpression.Left)},{TranslateExpression(bExpression.Right)})";
             }
 
-            if (bExpression.NodeType == ExpressionType.OrElse || bExpression.NodeType == ExpressionType.Or)
+            if (bExpression.NodeType == ExpressionType.OrElse)
             {
                 return $"({TranslateExpression(bExpression.Left)},|{TranslateExpression(bExpression.Right)})";
             }


### PR DESCRIPTION
Reverts redarrowlabs/Argo#59

realized that NodeType.And and NodeType.Or are for bitwise and/or, which doesn't make sense in this context