### PR TITLE
#67 Add response message to request failure exceptions

### DIFF
--- a/src/RedArrow.Argo.Client.Integration/Session/GetJustIdTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/GetJustIdTests.cs
@@ -40,8 +40,8 @@ namespace RedArrow.Argo.Client.Integration.Session
 
             using (var session = SessionFactory.CreateSession())
             {
-                await session.Delete(rltnId);
-                await session.Delete(modelId);
+                await session.Delete<BasicModel>(rltnId);
+                await session.Delete<ComplexModel>(modelId);
             }
         }
     }

--- a/src/RedArrow.Argo.Client/Exceptions/ArgoResponseException.cs
+++ b/src/RedArrow.Argo.Client/Exceptions/ArgoResponseException.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+
+namespace RedArrow.Argo.Client.Exceptions
+{
+    public class ArgoResponseException : Exception
+    {
+        /// <summary>
+        ///     Gets the content of a HTTP response message.
+        /// </summary>
+        public string ResponseContent { get; }
+        /// <summary>
+        ///     Gets the collection of HTTP response headers.
+        /// </summary>
+        public IDictionary<string, string> ResponseHeaders { get; }
+        /// <summary>
+        ///     Gets the reason phrase which typically is sent by servers together with
+        ///     the status code.
+        /// </summary>
+        public string ResponseReasonPhrase { get; }
+        /// <summary>
+        ///     Gets the status code of the HTTP response.
+        /// </summary>
+        public HttpStatusCode ResponseStatusCode { get; }
+
+        public ArgoResponseException(HttpResponseMessage response)
+        {
+            ResponseStatusCode = response.StatusCode;
+            ResponseReasonPhrase = response.ReasonPhrase;
+            ResponseHeaders = response.Headers?.ToDictionary(h => h.Key, h => string.Join(",", h.Value));
+
+            try
+            {
+                ResponseContent = response.Content?.ReadAsStringAsync().Result;
+            }
+            catch (Exception e)
+            {
+                ResponseContent = "Could not read the response content: " + e.Message;
+            }
+        }
+
+        /* Intentially not including the response body because it could include PHI
+         * which should not be sent to SEQ */
+        public override string Message => $"Response status code was unexpected: {(int)ResponseStatusCode}";
+    }
+}

--- a/src/RedArrow.Argo.Client/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/RedArrow.Argo.Client/Extensions/HttpResponseMessageExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using RedArrow.Argo.Client.Exceptions;
 
 namespace RedArrow.Argo.Client.Extensions
 {
@@ -31,6 +32,14 @@ namespace RedArrow.Argo.Client.Extensions
                 return JsonSerializer
                     .Create(jsonSettings)
                     .Deserialize<TModel>(jtr);
+            }
+        }
+
+        internal static void CheckStatusCode(this HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new ArgoResponseException(response);
             }
         }
     }

--- a/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
+++ b/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Config\Pipeline\IHttpClientBuilder.cs" />
     <Compile Include="Config\Pipeline\HttpClientBuilder.cs" />
     <Compile Include="Config\SessionFactoryConfiguration.cs" />
+    <Compile Include="Exceptions\ArgoResponseException.cs" />
     <Compile Include="Exceptions\MetaNotRegisteredException.cs" />
     <Compile Include="Exceptions\AttributeNotRegisteredException.cs" />
     <Compile Include="Exceptions\ManagedModelCreationException.cs" />

--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -123,7 +123,7 @@ namespace RedArrow.Argo.Client.Session
 
             var request = HttpRequestBuilder.CreateResource(rootResource, includes);
             var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
+            response.CheckStatusCode();
             if (response.StatusCode == HttpStatusCode.Created)
             {
                 var root = await response.GetContentModel<ResourceRootSingle>(JsonSettings);
@@ -156,7 +156,7 @@ namespace RedArrow.Argo.Client.Session
                 .ToArray();
             var request = HttpRequestBuilder.UpdateResource(patch, includes);
             var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
+            response.CheckStatusCode();
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -198,7 +198,7 @@ namespace RedArrow.Argo.Client.Session
             {
                 return default(TModel); // null
             }
-            response.EnsureSuccessStatusCode();
+            response.CheckStatusCode();
 
             var root = await response.GetContentModel<ResourceRootSingle>(JsonSettings);
             model = CreateResourceModel<TModel>(root.Data);
@@ -221,7 +221,7 @@ namespace RedArrow.Argo.Client.Session
             var response = HttpClient.SendAsync(request).GetAwaiter().GetResult();
             if (response.StatusCode == HttpStatusCode.NotFound) return null;
 
-            response.EnsureSuccessStatusCode();
+            response.CheckStatusCode();
 
             // TODO: perhaps use a 3rd ResourceRoot with JToken Data to determine if array was erroneously returned
             var root = response.GetContentModel<ResourceRootSingle>(JsonSettings).GetAwaiter().GetResult();
@@ -247,7 +247,7 @@ namespace RedArrow.Argo.Client.Session
         {
             var resourceType = ModelRegistry.GetResourceType<TModel>();
             var response = await HttpClient.DeleteAsync($"{resourceType}/{id}");
-            response.EnsureSuccessStatusCode();
+            response.CheckStatusCode();
             var model = Cache.Retrieve<TModel>(id);
             if (model != null)
             {
@@ -315,7 +315,7 @@ namespace RedArrow.Argo.Client.Session
             {
                 return Enumerable.Empty<TModel>();
             }
-            response.EnsureSuccessStatusCode();
+            response.CheckStatusCode();
 
             var root = await response.GetContentModel<ResourceRootCollection>(JsonSettings);
 
@@ -541,7 +541,7 @@ namespace RedArrow.Argo.Client.Session
             var response = HttpClient.SendAsync(request).GetAwaiter().GetResult();
             if (response.StatusCode == HttpStatusCode.NotFound) return;
 
-            response.EnsureSuccessStatusCode();
+            response.CheckStatusCode();
 
             // TODO: perhaps use a 3rd ResourceRoot with JToken Data to determine if object was erroneously returned
             var root = response.GetContentModel<ResourceRootCollection>(JsonSettings).GetAwaiter().GetResult();

--- a/src/RedArrow.Argo.TestUtils/IntegrationTest.cs
+++ b/src/RedArrow.Argo.TestUtils/IntegrationTest.cs
@@ -4,6 +4,7 @@ using RedArrow.Argo.Client.Http.Handlers.ExceptionLogger;
 using RedArrow.Argo.Client.Session;
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -23,6 +24,10 @@ namespace RedArrow.Argo.TestUtils
             Fixture = fixture;
             Fixture.ConfigureLogging(outputHelper);
             SessionFactory = CreateSessionFactory();
+
+            // Force the tests to allow TLS 1.2, since the test runners default to lower security protocols
+            // Otherwise you get a SocketException when hitting sandbox.redarrow.io
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
         }
 
         private ISessionFactory CreateSessionFactory()

--- a/src/RedArrow.Argo.TestUtils/IntegrationTestFixture.cs
+++ b/src/RedArrow.Argo.TestUtils/IntegrationTestFixture.cs
@@ -2,6 +2,7 @@
 using RedArrow.Argo.TestUtils.XUnitSink;
 using Serilog;
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using Xunit.Abstractions;
@@ -30,6 +31,10 @@ namespace RedArrow.Argo.TestUtils
         {
             using (var authClient = new HttpClient {BaseAddress = new Uri($"{Host}/security/")})
             {
+                // Force the tests to allow TLS 1.2, since the test runners default to lower security protocols
+                // Otherwise you get a SocketException when hitting sandbox.redarrow.io
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
                 var response = authClient.SendAsync(
                     new HttpRequestMessage(HttpMethod.Post, "authenticate")
                     {


### PR DESCRIPTION
#67 On a request failure, return an exception containing response content so the developer can more easily debug those failures.
Fixed some test issues.