### PR TITLE
Adds HttpRequestModifier to allow shuffling meta to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ var sessionFactory = Fluently.Configure("http://api.host.com")
         ResourceRetrieved = response => YourAsyncMethod(response),
         ResourceDeleted = response => YourAsyncMethod(response),
       })
+      .Use(new CustomHttpRequestModifier(ctorArg1))
       .UseGZipCompression()
       .UseRequestHandler<Xamarin.Android.Net.AndroidClientHandler>())
   .Models()

--- a/src/RedArrow.Argo.Client.Tests/Session/ISessionTests.cs
+++ b/src/RedArrow.Argo.Client.Tests/Session/ISessionTests.cs
@@ -152,7 +152,7 @@ namespace RedArrow.Argo.Client.Tests.Session
 
                     Assert.Empty(includes);
                 })
-                .Returns(expectedRequest);
+                .ReturnsAsync(expectedRequest);
 
             var mockHandler = new MockRequestHandler();
             mockHandler.Setup(
@@ -220,7 +220,7 @@ namespace RedArrow.Argo.Client.Tests.Session
                     Assert.Null(resource.Links);
                     Assert.Null(resource.Meta);
                 })
-                .Returns(expectedRequest);
+                .ReturnsAsync(expectedRequest);
 
             var mockHandler = new MockRequestHandler();
             mockHandler.Setup(
@@ -303,7 +303,7 @@ namespace RedArrow.Argo.Client.Tests.Session
 
             Assert.Equal(0, mockHandler.RequestsSent);
 
-            mockRequestBuilder.Verify(x => x.UpdateResource(It.IsAny<Resource>(), It.IsAny<IEnumerable<Resource>>()),
+            mockRequestBuilder.Verify(x => x.UpdateResource(It.IsAny<Resource>(), It.IsAny<Resource>(), It.IsAny<IEnumerable<Resource>>()),
                 Times.Never);
             mockCacheProvider.Verify(x => x.Update(It.IsAny<Guid>(), It.IsAny<object>()), Times.Never);
         }
@@ -325,19 +325,19 @@ namespace RedArrow.Argo.Client.Tests.Session
 
             var mockRequestBuilder = new Mock<IHttpRequestBuilder>();
             mockRequestBuilder
-                .Setup(x => x.UpdateResource(It.IsAny<Resource>(), It.IsAny<IEnumerable<Resource>>()))
-                .Callback<Resource, IEnumerable<Resource>>((resource, includes) =>
+                .Setup(x => x.UpdateResource(It.IsAny<Resource>(), It.IsAny<Resource>(), It.IsAny<IEnumerable<Resource>>()))
+                .Callback<Resource, Resource, IEnumerable<Resource>>((resource, patch, includes) =>
                 {
-                    Assert.Equal(modelId, resource.Id);
+                    Assert.Equal(modelId, patch.Id);
 
-                    Assert.Equal(modelPropA, resource.Attributes?["propertyA"]?.ToObject<string>());
-                    Assert.Equal(1, resource.Attributes.Count);
+                    Assert.Equal(modelPropA, patch.Attributes?["propertyA"]?.ToObject<string>());
+                    Assert.Equal(1, patch.Attributes.Count);
 
-                    Assert.NotNull(resource.Relationships);
-                    Assert.Equal(1, resource.Relationships.Count);
-                    Assert.Equal(JTokenType.Object, resource.Relationships["primaryBasicModel"]?.Data?.Type);
+                    Assert.NotNull(patch.Relationships);
+                    Assert.Equal(1, patch.Relationships.Count);
+                    Assert.Equal(JTokenType.Object, patch.Relationships["primaryBasicModel"]?.Data?.Type);
 
-                    var rltnIdentifier = resource.Relationships["primaryBasicModel"]
+                    var rltnIdentifier = patch.Relationships["primaryBasicModel"]
                         .Data.ToObject<ResourceIdentifier>();
                     Assert.NotEqual(Guid.Empty, rltnIdentifier.Id);
                     Assert.Equal(primaryBasicModel.Id, rltnIdentifier.Id);
@@ -351,10 +351,10 @@ namespace RedArrow.Argo.Client.Tests.Session
                     Assert.Equal(modelPropB, include.Attributes?["propB"]?.ToObject<string>());
                     Assert.Null(include.Relationships);
 
-                    Assert.Null(resource.Links);
-                    Assert.Null(resource.Meta);
+                    Assert.Null(patch.Links);
+                    Assert.Null(patch.Meta);
                 })
-                .Returns(expectedRequest);
+                .ReturnsAsync(expectedRequest);
 
             var mockHandler = new MockRequestHandler();
             mockHandler.Setup(

--- a/src/RedArrow.Argo.Client/Config/IRemoteConfigurator.cs
+++ b/src/RedArrow.Argo.Client/Config/IRemoteConfigurator.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using RedArrow.Argo.Client.Config.Pipeline;
+using RedArrow.Argo.Client.Http.Handlers.Request;
 
 namespace RedArrow.Argo.Client.Config
 {
@@ -12,5 +13,7 @@ namespace RedArrow.Argo.Client.Config
         IRemoteConfigurator ConfigureAsync(Func<HttpClient, Task> httpClient);
 
         IRemoteConfigurator Configure(Action<IHttpClientBuilder> builder);
+
+        IRemoteConfigurator Use(HttpRequestModifier httpRequestModifier);
     }
 }

--- a/src/RedArrow.Argo.Client/Config/SessionFactoryConfiguration.cs
+++ b/src/RedArrow.Argo.Client/Config/SessionFactoryConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using Newtonsoft.Json;
 using RedArrow.Argo.Client.Config.Model;
+using RedArrow.Argo.Client.Http.Handlers.Request;
 using RedArrow.Argo.Client.Session;
 
 namespace RedArrow.Argo.Client.Config
@@ -14,6 +15,8 @@ namespace RedArrow.Argo.Client.Config
         private ICollection<ModelConfiguration> ModelConfigurations { get; }
 
         private JsonSerializerSettings JsonSettings { get; set; }
+
+        private HttpRequestModifier HttpRequestModifier { get; set; }
 
         internal SessionFactoryConfiguration()
         {
@@ -30,9 +33,14 @@ namespace RedArrow.Argo.Client.Config
             JsonSettings = jsonSettings;
         }
 
+        internal void Configure(HttpRequestModifier httpRequestModifier)
+        {
+            HttpRequestModifier = httpRequestModifier;
+        }
+
         public ISessionFactory BuildSessionFactory()
         {
-            return new SessionFactory(HttpClientFactory, ModelConfigurations, JsonSettings);
+            return new SessionFactory(HttpClientFactory, ModelConfigurations, JsonSettings, HttpRequestModifier);
         }
     }
 }

--- a/src/RedArrow.Argo.Client/Http/Handlers/Request/BundledHttpRequestModifier.cs
+++ b/src/RedArrow.Argo.Client/Http/Handlers/Request/BundledHttpRequestModifier.cs
@@ -1,0 +1,65 @@
+﻿using RedArrow.Argo.Client.Model;
+using RedArrow.Argo.Client.Query;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace RedArrow.Argo.Client.Http.Handlers.Request
+{
+    internal class BundledHttpRequestModifier : HttpRequestModifier
+    {
+        private IList<HttpRequestModifier> HttpRequestModifiers { get; }
+        public BundledHttpRequestModifier(IList<HttpRequestModifier> modifiers)
+        {
+            HttpRequestModifiers = modifiers;
+        }
+
+        public override void GetResource(HttpRequestMessage request, Guid id, string resourceType)
+        {
+            foreach (var httpRequestModifier in HttpRequestModifiers)
+            {
+                httpRequestModifier.GetResource(request, id, resourceType);
+            }
+        }
+
+        public override void GetRelated(HttpRequestMessage request, Guid resourceId, string resourceType, string rltnName)
+        {
+            foreach (var httpRequestModifier in HttpRequestModifiers)
+            {
+                httpRequestModifier.GetRelated(request, resourceId, resourceType, rltnName);
+            }
+        }
+
+        public override void CreateResource(HttpRequestMessage request, ResourceRootSingle resource)
+        {
+            foreach (var httpRequestModifier in HttpRequestModifiers)
+            {
+                httpRequestModifier.CreateResource(request, resource);
+            }
+        }
+
+        public override void UpdateResource(HttpRequestMessage request, Resource resource, ResourceRootSingle patch)
+        {
+            foreach (var httpRequestModifier in HttpRequestModifiers)
+            {
+                httpRequestModifier.UpdateResource(request, resource, patch);
+            }
+        }
+
+        public override void QueryResources(HttpRequestMessage request, IQueryContext query)
+        {
+            foreach (var httpRequestModifier in HttpRequestModifiers)
+            {
+                httpRequestModifier.QueryResources(request, query);
+            }
+        }
+
+        public override void DeleteResource(HttpRequestMessage request, Guid id, string resourceType)
+        {
+            foreach (var httpRequestModifier in HttpRequestModifiers)
+            {
+                httpRequestModifier.DeleteResource(request, id, resourceType);
+            }
+        }
+    }
+}

--- a/src/RedArrow.Argo.Client/Http/Handlers/Request/HttpRequestModifier.cs
+++ b/src/RedArrow.Argo.Client/Http/Handlers/Request/HttpRequestModifier.cs
@@ -1,0 +1,73 @@
+﻿using RedArrow.Argo.Client.Model;
+using RedArrow.Argo.Client.Query;
+using System;
+using System.Net.Http;
+
+namespace RedArrow.Argo.Client.Http.Handlers.Request
+{
+    /// <summary>
+    /// Defines interceptors for Argo http requests with additional context, allowing
+    /// the implementer to change the request before it is sent.  One example might be
+    /// shuffling metadata like ETags between the resource and the headers.
+    /// </summary>
+    public abstract class HttpRequestModifier
+    {
+        /// <summary>
+        /// Modifies requests for individual resources
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="id">Resource ID</param>
+        /// <param name="resourceType">Resource Type</param>
+        public virtual void GetResource(HttpRequestMessage request, Guid id, string resourceType)
+        {
+            // Do nothing
+        }
+
+        /// <summary>
+        /// Modifies requests for related resources
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="resourceId">Owner Resource ID</param>
+        /// <param name="resourceType">Owner Resource Type</param>
+        /// <param name="rltnName">Relationship Name</param>
+        public virtual void GetRelated(HttpRequestMessage request, Guid resourceId, string resourceType, string rltnName)
+        {
+            // Do nothing
+        }
+
+        /// <summary>
+        /// Modifies requests to create a resource
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="resource">Resource being created</param>
+        public virtual void CreateResource(HttpRequestMessage request, ResourceRootSingle resource)
+        {
+            // Do nothing
+        }
+
+        /// <summary>
+        /// Modifies requests to update a resource
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="resource">Resource being updated</param>
+        public virtual void UpdateResource(HttpRequestMessage request, Resource resource, ResourceRootSingle patch)
+        {
+            // Do nothing
+        }
+
+        /// <summary>
+        /// Modifies requests to query resources
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="query">Query Context</param>
+        public virtual void QueryResources(HttpRequestMessage request, IQueryContext query)
+        {
+            // Do nothing
+        }
+
+        public virtual void DeleteResource(HttpRequestMessage request, Guid id, string resourceType)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/src/RedArrow.Argo.Client/Http/HttpRequestBuilder.cs
+++ b/src/RedArrow.Argo.Client/Http/HttpRequestBuilder.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RedArrow.Argo.Client.Flurl.Shared;
+using RedArrow.Argo.Client.Http.Handlers.Request;
 using RedArrow.Argo.Client.Model;
 using RedArrow.Argo.Client.Query;
 
@@ -14,10 +18,15 @@ namespace RedArrow.Argo.Client.Http
         private const string JsonApiHeader = "application/vnd.api+json";
 
         private JsonSerializerSettings JsonSettings { get; }
+        private HttpRequestModifier HttpRequestModifier { get; }
 
-        public HttpRequestBuilder(JsonSerializerSettings jsonSettings)
+        public HttpRequestBuilder(
+            JsonSerializerSettings jsonSettings,
+            HttpRequestModifier httpRequestModifier)
         {
             JsonSettings = jsonSettings;
+            // RequestModifier can be null
+            HttpRequestModifier = httpRequestModifier;
         }
 
         public HttpRequestMessage GetResource(Guid id, string resourceType, string include)
@@ -27,40 +36,51 @@ namespace RedArrow.Argo.Client.Http
             {
                 path = path.SetQueryParam("include", include);
             }
-            return new HttpRequestMessage(HttpMethod.Get, path);
+            var request = new HttpRequestMessage(HttpMethod.Get, path);
+            HttpRequestModifier?.GetResource(request, id, resourceType);
+            return request;
         }
 
         public HttpRequestMessage GetRelated(Guid id, string resourceType, string rltnName)
         {
-            return new HttpRequestMessage(HttpMethod.Get, $"{resourceType}/{id}/{rltnName}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{resourceType}/{id}/{rltnName}");
+            HttpRequestModifier?.GetRelated(request, id, resourceType, rltnName);
+            return request;
         }
 
-        public HttpRequestMessage CreateResource(Resource resource, IEnumerable<Resource> include)
+        public async Task<HttpRequestMessage> CreateResource(Resource resource, IEnumerable<Resource> include)
         {
             var root = ResourceRootSingle.FromResource(resource, include);
 
-            return new HttpRequestMessage(HttpMethod.Post, resource.Type)
+            var request = new HttpRequestMessage(HttpMethod.Post, resource.Type);
+            HttpRequestModifier?.CreateResource(request, root);
+            // Allowing the RequestModifier to set custom content, if they really wanted to
+            if (request.Content == null)
             {
-                Content = BuildHttpContent(root.ToJson(JsonSettings)),
-            };
+                request.Content = await BuildHttpContent(root);
+            }
+            return request;
         }
 
-        public HttpRequestMessage UpdateResource(Resource patch, IEnumerable<Resource> include)
+        public async Task<HttpRequestMessage> UpdateResource(Resource resource, Resource patch, IEnumerable<Resource> include)
         {
             var root = ResourceRootSingle.FromResource(patch, include);
 
-            // TODO: investigate - writing via stream may be more performant / smaller memory footprint
-            // TODO: since it would avoid loading potentially large strings into memory
-            //var stream = new MemoryStream();
-            //var sr = new StreamWriter(stream);
-            //var writer = new JsonTextWriter(sr);
-            //new JsonSerializer().Serialize(writer, root);
-            //var content = new StreamContent(stream);
-
-            return new HttpRequestMessage(new HttpMethod("PATCH"), $"{patch.Type}/{patch.Id}")
+            var request = new HttpRequestMessage(new HttpMethod("PATCH"), $"{patch.Type}/{patch.Id}");
+            HttpRequestModifier?.UpdateResource(request, resource, root);
+            // Allowing the RequestModifier to set custom content, if they really wanted to
+            if (request.Content == null)
             {
-                Content = BuildHttpContent(root.ToJson(JsonSettings))
-            };
+                request.Content = await BuildHttpContent(root);
+            }
+            return request;
+        }
+
+        public HttpRequestMessage DeleteResource(string resourceType, Guid id)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"{resourceType}/{id}");
+            HttpRequestModifier?.DeleteResource(request, id, resourceType);
+            return request;
         }
 
         public HttpRequestMessage QueryResources(IQueryContext query, string include)
@@ -71,13 +91,35 @@ namespace RedArrow.Argo.Client.Http
                 path = path.SetQueryParam("include", include);
             }
 
-            return new HttpRequestMessage(HttpMethod.Get, path);
+            var request = new HttpRequestMessage(HttpMethod.Get, path);
+            HttpRequestModifier?.QueryResources(request, query);
+            return request;
         }
 
-        private static HttpContent BuildHttpContent(string content)
+        private async Task<HttpContent> BuildHttpContent(ResourceRootSingle root)
         {
-            // TODO: investigate StreamContent as it could offer performance and memory footprint benefits for large objects
-            return new StringContent(content, Encoding.UTF8, JsonApiHeader);
+            /* The streaming approach appears to have reduced the memory footprint by a decent
+             * margin (maybe a third). I suspect that StringContent just copies the string to a
+             * MemoryStream anyway so we're only reducing that extra step of string to stream. */
+            //return new StringContent(root.ToJson(JsonSettings), Encoding.UTF8, JsonApiHeader);
+
+            // These settings were set by root.ToJson
+            JsonSettings.NullValueHandling = NullValueHandling.Ignore;
+            JsonSettings.Formatting = Formatting.None;
+            var serializer = JsonSerializer.Create(JsonSettings);
+
+            var stream = new MemoryStream();
+            var sr = new StreamWriter(stream);
+            var writer = new JsonTextWriter(sr);
+            serializer.Serialize(writer, root);
+            await writer.FlushAsync();
+            stream.Seek(0, SeekOrigin.Begin);
+            var content = new StreamContent(stream);
+            content.Headers.ContentType = new MediaTypeHeaderValue(JsonApiHeader)
+            {
+                CharSet = Encoding.UTF8.WebName
+            };
+            return content;
         }
     }
 }

--- a/src/RedArrow.Argo.Client/Http/IHttpRequestBuilder.cs
+++ b/src/RedArrow.Argo.Client/Http/IHttpRequestBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using RedArrow.Argo.Client.Model;
 using RedArrow.Argo.Client.Query;
 
@@ -10,8 +11,9 @@ namespace RedArrow.Argo.Client.Http
     {
         HttpRequestMessage GetResource(Guid id, string resourceType, string include);
         HttpRequestMessage GetRelated(Guid resourceId, string resourceType, string rltnName);
-        HttpRequestMessage CreateResource(Resource resource, IEnumerable<Resource> included);
-        HttpRequestMessage UpdateResource(Resource patch, IEnumerable<Resource> included);
+        Task<HttpRequestMessage> CreateResource(Resource resource, IEnumerable<Resource> included);
+        Task<HttpRequestMessage> UpdateResource(Resource resource, Resource patch, IEnumerable<Resource> included);
+        HttpRequestMessage DeleteResource(string resourceType, Guid id);
 
         HttpRequestMessage QueryResources(IQueryContext query, string include);
     }

--- a/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
+++ b/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
@@ -85,6 +85,8 @@
     <Compile Include="Http\Handlers\GZip\GZipCompressionHandler.cs" />
     <Compile Include="Http\Handlers\GZip\GZipContent.cs" />
     <Compile Include="Http\Handlers\GZip\HttpClientBuilderExtensions.cs" />
+    <Compile Include="Http\Handlers\Request\BundledHttpRequestModifier.cs" />
+    <Compile Include="Http\Handlers\Request\HttpRequestModifier.cs" />
     <Compile Include="Http\Handlers\Response\HttpClientBuilderExtensions.cs" />
     <Compile Include="Http\Handlers\Response\ResponseHandler.cs" />
     <Compile Include="Http\Handlers\Response\ResponseHandlerOptions.cs" />

--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -121,7 +121,7 @@ namespace RedArrow.Argo.Client.Session
                 }
             }
 
-            var request = HttpRequestBuilder.CreateResource(rootResource, includes);
+            var request = await HttpRequestBuilder.CreateResource(rootResource, includes);
             var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
             response.CheckStatusCode();
             if (response.StatusCode == HttpStatusCode.Created)
@@ -154,7 +154,8 @@ namespace RedArrow.Argo.Client.Session
                 .Where(ModelRegistry.IsUnmanagedModel)
                 .Select(CreateModelResource)
                 .ToArray();
-            var request = HttpRequestBuilder.UpdateResource(patch, includes);
+            var resource = ModelRegistry.GetResource(model);
+            var request = await HttpRequestBuilder.UpdateResource(resource, patch, includes);
             var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
             response.CheckStatusCode();
 
@@ -246,7 +247,8 @@ namespace RedArrow.Argo.Client.Session
         public async Task Delete<TModel>(Guid id)
         {
             var resourceType = ModelRegistry.GetResourceType<TModel>();
-            var response = await HttpClient.DeleteAsync($"{resourceType}/{id}");
+            var request = HttpRequestBuilder.DeleteResource(resourceType, id);
+            var response = await HttpClient.SendAsync(request);
             response.CheckStatusCode();
             var model = Cache.Retrieve<TModel>(id);
             if (model != null)

--- a/src/RedArrow.Argo.Client/Session/SessionFactory.cs
+++ b/src/RedArrow.Argo.Client/Session/SessionFactory.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using RedArrow.Argo.Client.Cache;
 using RedArrow.Argo.Client.Config.Model;
 using RedArrow.Argo.Client.Http;
+using RedArrow.Argo.Client.Http.Handlers.Request;
 using RedArrow.Argo.Client.Session.Registry;
 
 namespace RedArrow.Argo.Client.Session
@@ -14,15 +15,18 @@ namespace RedArrow.Argo.Client.Session
         private Func<HttpClient> HttpClientFactory { get; }
         private IEnumerable<ModelConfiguration> ModelConfigurations { get; }
         private JsonSerializerSettings JsonSettings { get; }
+        private HttpRequestModifier HttpRequestModifier { get; }
 
         internal SessionFactory(
             Func<HttpClient> httpClientFactory,
             IEnumerable<ModelConfiguration> modelConfigurations,
-            JsonSerializerSettings jsonSettings)
+            JsonSerializerSettings jsonSettings,
+            HttpRequestModifier httpRequestModifier)
         {
             HttpClientFactory = httpClientFactory;
             ModelConfigurations = modelConfigurations;
             JsonSettings = jsonSettings;
+            HttpRequestModifier = httpRequestModifier;
         }
 
         public ISession CreateSession(Action<HttpClient> configureClient = null)
@@ -34,7 +38,7 @@ namespace RedArrow.Argo.Client.Session
                     configureClient?.Invoke(client);
                     return client;
                 },
-                new HttpRequestBuilder(JsonSettings),
+                new HttpRequestBuilder(JsonSettings, HttpRequestModifier),
                 new BasicCacheProvider(modelRegistry),
                 modelRegistry,
                 JsonSettings);

--- a/src/RedArrow.Argo.TestUtils/EtagRequestModifier.cs
+++ b/src/RedArrow.Argo.TestUtils/EtagRequestModifier.cs
@@ -1,0 +1,28 @@
+﻿using RedArrow.Argo.Client.Http.Handlers.Request;
+using RedArrow.Argo.Client.Model;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace RedArrow.Argo.TestUtils
+{
+    public class EtagRequestModifier : HttpRequestModifier
+    {
+        public override void UpdateResource(HttpRequestMessage request, Resource resource, ResourceRootSingle patch)
+        {
+            resource.GetMeta().TryGetValue("system", out var system);
+            var eTag = system?.Value<string>("eTag");
+            if (eTag != null)
+            {
+                request.Headers.IfMatch.Add(new EntityTagHeaderValue(eTag));
+            }
+        }
+
+        public override void DeleteResource(HttpRequestMessage request, Guid id, string resourceType)
+        {
+            // Delete anything
+            request.Headers.IfMatch.Add(EntityTagHeaderValue.Any);
+        }
+    }
+}

--- a/src/RedArrow.Argo.TestUtils/IntegrationTestFixture.cs
+++ b/src/RedArrow.Argo.TestUtils/IntegrationTestFixture.cs
@@ -31,10 +31,6 @@ namespace RedArrow.Argo.TestUtils
         {
             using (var authClient = new HttpClient {BaseAddress = new Uri($"{Host}/security/")})
             {
-                // Force the tests to allow TLS 1.2, since the test runners default to lower security protocols
-                // Otherwise you get a SocketException when hitting sandbox.redarrow.io
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
-
                 var response = authClient.SendAsync(
                     new HttpRequestMessage(HttpMethod.Post, "authenticate")
                     {

--- a/src/RedArrow.Argo.TestUtils/RedArrow.Argo.TestUtils.csproj
+++ b/src/RedArrow.Argo.TestUtils/RedArrow.Argo.TestUtils.csproj
@@ -79,6 +79,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EtagRequestModifier.cs" />
     <Compile Include="IntegrationTest.cs" />
     <Compile Include="IntegrationTestFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Based on the need to set the eTag meta value as a request header.  The HttpRequestModifier gives access to the request before it is sent, along with the context of which entity is being changed.  Modifiers are given for every session request type.