### PR TITLE
 Convert Meta to JObject.  Merge API responses into model instances

### DIFF
--- a/src/RedArrow.Argo.Client.Integration/Linq/Queryables/QueryTypeTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Linq/Queryables/QueryTypeTests.cs
@@ -49,7 +49,7 @@ namespace RedArrow.Argo.Client.Integration.Linq.Queryables
                 var parent = new ComplexModel
                 {
                     Id = parentId,
-                    BasicModels = childIds.Select(x => new BasicModel {Id = x})
+                    BasicModels = childIds.Select(x => new BasicModel {Id = x}).ToList()
                 };
 
                 await session.Create(parent);

--- a/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
@@ -95,6 +95,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(initialLastName, patient.LastName);
 
                 patient.LastName = updatedLastName;
+                patient.Etag = "\"*\"";
 
                 Assert.Equal(updatedLastName, patient.LastName);
 

--- a/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
@@ -95,7 +95,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(initialLastName, patient.LastName);
 
                 patient.LastName = updatedLastName;
-                patient.Etag = "\"*\"";
+                patient.Etag = "*";
 
                 Assert.Equal(updatedLastName, patient.LastName);
 

--- a/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
@@ -73,7 +73,11 @@ namespace RedArrow.Argo.Client.Integration.Session
                     LastName = initialLastName
                 };
 
-                patient = await session.Create(patient);
+                await session.Create(patient);
+
+                // The Create call should also mutate the passed in model with new Meta or attributes
+                Assert.NotEqual(DateTime.MinValue, patient.Created);
+                Assert.NotNull(patient.Etag);
 
                 Assert.NotEqual(Guid.Empty, patient.Id);
                 Assert.Equal(initialFirstName, patient.FirstName);
@@ -95,13 +99,18 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(initialLastName, patient.LastName);
 
                 patient.LastName = updatedLastName;
-                patient.Etag = "*";
 
                 Assert.Equal(updatedLastName, patient.LastName);
+
+                var oldUpdatedAt = patient.UpdatedAt;
+                var oldEtag = patient.Etag;
 
                 await session.Update(patient);
                 Assert.Equal(initialFirstName, patient.FirstName);
                 Assert.Equal(updatedLastName, patient.LastName);
+                // The Update call should also mutate the passed in model with new Meta or attributes
+                Assert.NotEqual(oldUpdatedAt, patient.UpdatedAt);
+                Assert.NotEqual(oldEtag, patient.Etag);
 
                 var patient2 = await session.Get<Patient>(crossSessionId);
 

--- a/src/RedArrow.Argo.Client.Integration/Session/GetJustIdTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/GetJustIdTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Ploeh.AutoFixture.Xunit2;
 using RedArrow.Argo.TestUtils;
@@ -26,9 +28,12 @@ namespace RedArrow.Argo.Client.Integration.Session
                 modelId = model.Id;
 
                 model.PrimaryBasicModel = new BasicModel();
+                model.BasicModels.Add(model.PrimaryBasicModel);
 
                 await session.Update(model);
                 rltnId = model.PrimaryBasicModel.Id;
+                Assert.Equal(rltnId, model.PrimaryBasicModelId);
+                Assert.Equal(rltnId, model.BasicModelIds.Single());
             }
 
             using (var session = SessionFactory.CreateSession())
@@ -36,6 +41,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 var persistedModel = await session.Get<ComplexModel>(modelId);
 
                 Assert.Equal(rltnId, persistedModel.PrimaryBasicModelId);
+                Assert.Equal(rltnId, persistedModel.BasicModelIds.Single());
             }
 
             using (var session = SessionFactory.CreateSession())

--- a/src/RedArrow.Argo.Client.Integration/Session/MetaTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/MetaTests.cs
@@ -17,7 +17,7 @@ namespace RedArrow.Argo.Client.Integration.Session
 
         [Theory, AutoData, Trait("Category", "Integration")]
         public async Task GetSetMetaPersisted
-            (DateTime created, string version)
+            (DateTime contactTime, string version)
         {
             Guid id;
             using (var session = SessionFactory.CreateSession())
@@ -25,10 +25,10 @@ namespace RedArrow.Argo.Client.Integration.Session
                 var patient = await session.Create<Patient>();
                 id = patient.Id;
 
-                patient.Created = created;
+                patient.ContactTime = contactTime;
                 patient.Version = version;
 
-                Assert.Equal(created, patient.Created);
+                Assert.Equal(contactTime, patient.ContactTime);
                 Assert.Equal(version, patient.Version);
             }
 
@@ -36,7 +36,7 @@ namespace RedArrow.Argo.Client.Integration.Session
             {
                 var patient = await session.Get<Patient>(id);
 
-                Assert.Equal(DateTime.MinValue, patient.Created);
+                Assert.Equal(DateTime.MinValue, patient.ContactTime);
                 Assert.Null(patient.Version);
             }
         }
@@ -44,7 +44,7 @@ namespace RedArrow.Argo.Client.Integration.Session
         [Fact, Trait("Category", "Integration")]
         public async Task CreateGetDeletePatient()
         {
-            var initialCreated = DateTime.UtcNow;
+            var initialContactTime = DateTime.UtcNow;
             var initialVersion = "abcdef123456789";
 
             var updatedVersion = "987654321fdecba";
@@ -55,21 +55,21 @@ namespace RedArrow.Argo.Client.Integration.Session
             {
                 var patient = new Patient
                 {
-                    Created = initialCreated,
+                    ContactTime = initialContactTime,
                     Version = initialVersion
                 };
 
                 patient = await session.Create(patient);
 
                 Assert.NotEqual(Guid.Empty, patient.Id);
-                Assert.Equal(initialCreated, patient.Created.ToUniversalTime());
+                Assert.Equal(initialContactTime, patient.ContactTime.ToUniversalTime());
                 Assert.Equal(initialVersion, patient.Version);
 
                 crossSessionId = patient.Id;
 
                 var patientRef = await session.Get<Patient>(crossSessionId);
                 
-                Assert.Equal(patient.Created, patientRef.Created);
+                Assert.Equal(patient.ContactTime, patientRef.ContactTime);
                 Assert.Equal(patient.Version, patientRef.Version);
             }
             // update!
@@ -78,7 +78,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 var patient = await session.Get<Patient>(crossSessionId);
 
                 Assert.Equal(crossSessionId, patient.Id);
-                Assert.Equal(initialCreated, patient.Created.ToUniversalTime());
+                Assert.Equal(initialContactTime, patient.ContactTime.ToUniversalTime());
                 Assert.Equal(initialVersion, patient.Version);
 
                 patient.Version = updatedVersion;
@@ -86,13 +86,13 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(updatedVersion, patient.Version);
 
                 await session.Update(patient);
-                Assert.Equal(initialCreated, patient.Created.ToUniversalTime());
+                Assert.Equal(initialContactTime, patient.ContactTime.ToUniversalTime());
                 Assert.Equal(updatedVersion, patient.Version);
 
                 var patient2 = await session.Get<Patient>(crossSessionId);
 
                 Assert.Equal(patient.Id, patient2.Id);
-                Assert.Equal(patient.Created, patient2.Created);
+                Assert.Equal(patient.ContactTime, patient2.ContactTime);
                 Assert.Equal(patient.Version, patient2.Version);
             }
             // later that day...
@@ -101,7 +101,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 var patient = await session.Get<Patient>(crossSessionId);
 
                 Assert.Equal(crossSessionId, patient.Id);
-                Assert.Equal(initialCreated, patient.Created.ToUniversalTime());
+                Assert.Equal(initialContactTime, patient.ContactTime.ToUniversalTime());
                 Assert.Equal(updatedVersion, patient.Version);
             }
             // cleanup

--- a/src/RedArrow.Argo.Client.Tests/Session/ISessionTests.cs
+++ b/src/RedArrow.Argo.Client.Tests/Session/ISessionTests.cs
@@ -133,7 +133,6 @@ namespace RedArrow.Argo.Client.Tests.Session
             };
 
             var expectedRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(uri));
-            var expectedResultModel = new BasicModel();
 
             var mockRequestBuilder = new Mock<IHttpRequestBuilder>();
             mockRequestBuilder
@@ -164,9 +163,6 @@ namespace RedArrow.Argo.Client.Tests.Session
                 });
 
             var mockCacheProvider = new Mock<ICacheProvider>();
-            mockCacheProvider
-                .Setup(x => x.Retrieve<BasicModel>(expectedModelId))
-                .Returns(expectedResultModel);
 
             var modelRegistry = CreateModelRegistry(typeof(BasicModel));
 
@@ -179,10 +175,10 @@ namespace RedArrow.Argo.Client.Tests.Session
             var result = await subject.Create(model);
 
             Assert.NotNull(result);
-            Assert.Same(expectedResultModel, result);
+            Assert.Same(model, result);
 
             mockCacheProvider
-                .Verify(x => x.Update(expectedModelId, It.IsAny<BasicModel>()), Times.Once);
+                .Verify(x => x.Update(expectedModelId, model), Times.Once);
         }
 
         [Theory, AutoData]
@@ -201,7 +197,6 @@ namespace RedArrow.Argo.Client.Tests.Session
             c.A = a;
 
             var expectedRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(uri));
-            var expectedResultModel = new CircularReferenceA();
 
             var mockRequestBuilder = new Mock<IHttpRequestBuilder>();
             mockRequestBuilder
@@ -232,9 +227,6 @@ namespace RedArrow.Argo.Client.Tests.Session
                 });
 
             var mockCacheProvider = new Mock<ICacheProvider>();
-            mockCacheProvider
-                .Setup(x => x.Retrieve<CircularReferenceA>(modelId))
-                .Returns(expectedResultModel);
 
             var modelRegistry = CreateModelRegistry(
                 typeof(CircularReferenceA),
@@ -250,7 +242,7 @@ namespace RedArrow.Argo.Client.Tests.Session
             var result = await subject.Create(a);
 
             Assert.NotNull(result);
-            Assert.Same(expectedResultModel, result);
+            Assert.Same(a, result);
 
             mockCacheProvider
                 .Verify(x => x.Update(It.IsAny<Guid>(), It.IsAny<CircularReferenceA>()), Times.Once);

--- a/src/RedArrow.Argo.Client.Tests/Session/ISessionTests.cs
+++ b/src/RedArrow.Argo.Client.Tests/Session/ISessionTests.cs
@@ -386,7 +386,7 @@ namespace RedArrow.Argo.Client.Tests.Session
 
             await subject.Update(model);
 
-            mockCacheProvider.Verify(x => x.Update(model.PrimaryBasicModel.Id, model.PrimaryBasicModel), Times.Once);
+            mockCacheProvider.Verify(x => x.Update(model.PrimaryBasicModel.Id, model.PrimaryBasicModel));
             mockCacheProvider.Verify(x => x.Update(model.Id, model), Times.Never);
         }
 

--- a/src/RedArrow.Argo.Client.Tests/Session/Registry/ModelRegistryTests.cs
+++ b/src/RedArrow.Argo.Client.Tests/Session/Registry/ModelRegistryTests.cs
@@ -311,7 +311,7 @@ namespace RedArrow.Argo.Client.Tests.Session.Registry
             var result = subject.GetMetaValues(model);
 
             Assert.Equal(expectedMeta1, result["meta1"].ToObject<string>());
-            Assert.False(result.ContainsKey("meta-2"));
+            Assert.False(result.TryGetValue("meta-2", out var meta2));
             Assert.Equal(expectedMeta3, result["meta3"].ToObject<long>());
         }
 

--- a/src/RedArrow.Argo.Client/Extensions/JObjectExtensions.cs
+++ b/src/RedArrow.Argo.Client/Extensions/JObjectExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace RedArrow.Argo.Client.Extensions
+{
+    public static class JObjectExtensions
+    {
+        public static void SetMetaValue(this JObject meta, string metaName, object value)
+        {
+            var path = metaName.Split('.');
+            var nextMeta = meta;
+            // Navigate or build the object structure to the desired Meta
+            for (int i = 0; i < path.Length - 1; i++)
+            {
+                var segment = path[i];
+                if (nextMeta.TryGetValue(segment, out var subMeta))
+                {
+                    // Navigate to the next node
+                    nextMeta = (JObject)subMeta;
+                }
+                else
+                {
+                    // Create a new node and navigate to it
+                    var newMeta = new JObject();
+                    nextMeta[segment] = newMeta;
+                    nextMeta = newMeta;
+                }
+            }
+            // Set the Meta at the terminal node
+            var lastSegment = path[path.Length - 1];
+            nextMeta[lastSegment] = JToken.FromObject(value);
+        }
+    }
+}

--- a/src/RedArrow.Argo.Client/Extensions/TypeExtensions.cs
+++ b/src/RedArrow.Argo.Client/Extensions/TypeExtensions.cs
@@ -19,6 +19,13 @@ namespace RedArrow.Argo.Client.Extensions
                        .FirstOrDefault() ?? type.Name.Camelize();
         }
 
+        public static MethodInfo GetInitializeMethod(this Type type)
+        {
+            return type.GetTypeInfo()
+                .DeclaredMethods
+                .Single(method => method.Name == "__argo__generated_Initialize");
+        }
+
         public static FieldInfo GetSessionField(this Type type)
         {
             return type.GetTypeInfo()

--- a/src/RedArrow.Argo.Client/Http/Handlers/Request/BundledHttpRequestModifier.cs
+++ b/src/RedArrow.Argo.Client/Http/Handlers/Request/BundledHttpRequestModifier.cs
@@ -38,11 +38,11 @@ namespace RedArrow.Argo.Client.Http.Handlers.Request
             }
         }
 
-        public override void UpdateResource(HttpRequestMessage request, Resource resource, ResourceRootSingle patch)
+        public override void UpdateResource(HttpRequestMessage request, Resource originalResource, ResourceRootSingle patch)
         {
             foreach (var httpRequestModifier in HttpRequestModifiers)
             {
-                httpRequestModifier.UpdateResource(request, resource, patch);
+                httpRequestModifier.UpdateResource(request, originalResource, patch);
             }
         }
 

--- a/src/RedArrow.Argo.Client/Http/Handlers/Request/HttpRequestModifier.cs
+++ b/src/RedArrow.Argo.Client/Http/Handlers/Request/HttpRequestModifier.cs
@@ -49,8 +49,9 @@ namespace RedArrow.Argo.Client.Http.Handlers.Request
         /// Modifies requests to update a resource
         /// </summary>
         /// <param name="request"></param>
-        /// <param name="resource">Resource being updated</param>
-        public virtual void UpdateResource(HttpRequestMessage request, Resource resource, ResourceRootSingle patch)
+        /// <param name="originalResource">Resource being updated</param>
+        /// <param name="patch">Resource patch</param>
+        public virtual void UpdateResource(HttpRequestMessage request, Resource originalResource, ResourceRootSingle patch)
         {
             // Do nothing
         }

--- a/src/RedArrow.Argo.Client/Model/BaseResourceRoot.cs
+++ b/src/RedArrow.Argo.Client/Model/BaseResourceRoot.cs
@@ -16,7 +16,7 @@ namespace RedArrow.Argo.Client.Model
         public IList<Error> Errors { get; set; }
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
-        public IDictionary<string, JToken> Meta { get; set; }
+        public JObject Meta { get; set; }
 
         [JsonProperty("links", NullValueHandling = NullValueHandling.Ignore)]
         public IDictionary<string, JToken> Links { get; set; }

--- a/src/RedArrow.Argo.Client/Model/Error.cs
+++ b/src/RedArrow.Argo.Client/Model/Error.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
 
 namespace RedArrow.Argo.Client.Model
 {
@@ -29,7 +28,7 @@ namespace RedArrow.Argo.Client.Model
         public ErrorSource Source { get; set; }
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
-        public IDictionary<string, JToken> Meta { get; set; }
+        public JObject Meta { get; set; }
 
         internal Error()
         {

--- a/src/RedArrow.Argo.Client/Model/IMetaDecorated.cs
+++ b/src/RedArrow.Argo.Client/Model/IMetaDecorated.cs
@@ -5,6 +5,6 @@ namespace RedArrow.Argo.Client.Model
 {
     public interface IMetaDecorated
     {
-        IDictionary<string, JToken> Meta { get; set; }
+        JObject Meta { get; set; }
     }
 }

--- a/src/RedArrow.Argo.Client/Model/Link.cs
+++ b/src/RedArrow.Argo.Client/Model/Link.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
 
 namespace RedArrow.Argo.Client.Model
 {
@@ -11,7 +10,7 @@ namespace RedArrow.Argo.Client.Model
         public Uri Href { get; set; }
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
-        public IDictionary<string, JToken> Meta { get; set; }
+        public JObject Meta { get; set; }
 
         internal Link()
         {

--- a/src/RedArrow.Argo.Client/Model/Relationship.cs
+++ b/src/RedArrow.Argo.Client/Model/Relationship.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace RedArrow.Argo.Client.Model
 {
@@ -13,7 +13,7 @@ namespace RedArrow.Argo.Client.Model
         public JToken Data { get; set; }
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
-        public IDictionary<string, JToken> Meta { get; set; }
+        public JObject Meta { get; set; }
 
         internal Relationship()
         {

--- a/src/RedArrow.Argo.Client/Model/Resource.cs
+++ b/src/RedArrow.Argo.Client/Model/Resource.cs
@@ -29,7 +29,10 @@ namespace RedArrow.Argo.Client.Model
         {
             GetAttributes().Merge(patch.Attributes);
             patch.Relationships?.Each(kvp => GetRelationships()[kvp.Key] = kvp.Value);
-            patch.Meta?.Each(kvp => GetMeta()[kvp.Key] = kvp.Value);
+            if (patch.Meta != null)
+            {
+                GetMeta().Merge(patch.Meta);
+            }
         }
 
         public JObject GetAttributes()
@@ -52,14 +55,14 @@ namespace RedArrow.Argo.Client.Model
             return Links ?? (Links = new Dictionary<string, JToken>());
         }
 
-        public IDictionary<string, JToken> GetMeta()
+        public JObject GetMeta()
         {
-            return Meta ?? (Meta = new Dictionary<string, JToken>());
+            return Meta ?? (Meta = new JObject());
         }
 
         public void SetMeta(string metaName, object value)
         {
-            GetMeta()[metaName] = JToken.FromObject(value);
+            GetMeta().SetMetaValue(metaName, value);
         }
     }
 

--- a/src/RedArrow.Argo.Client/Model/ResourceIdentifier.cs
+++ b/src/RedArrow.Argo.Client/Model/ResourceIdentifier.cs
@@ -15,7 +15,7 @@ namespace RedArrow.Argo.Client.Model
         public string Type { get; set; }
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
-        public IDictionary<string, JToken> Meta { get; set; }
+        public JObject Meta { get; set; }
 
         internal ResourceIdentifier()
         {

--- a/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
+++ b/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\HttpClientExtensions.cs" />
     <Compile Include="Extensions\HttpResponseMessageExtensions.cs" />
+    <Compile Include="Extensions\JObjectExtensions.cs" />
     <Compile Include="Extensions\MemberInfoExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />

--- a/src/RedArrow.Argo.Client/Session/Registry/IModelRegistry.cs
+++ b/src/RedArrow.Argo.Client/Session/Registry/IModelRegistry.cs
@@ -44,7 +44,7 @@ namespace RedArrow.Argo.Client.Session.Registry
         JObject GetAttributeValues(object model);
         IDictionary<string, Relationship> GetRelationshipValues(object model);
         TMeta GetMetaValue<TModel, TMeta>(TModel model, string metaName);
-        IDictionary<string, JToken> GetMetaValues(object model);
+        JObject GetMetaValues(object model);
 
         IEnumerable<RelationshipConfiguration> GetHasOneConfigs<TModel>();
         IEnumerable<RelationshipConfiguration> GetHasOneConfigs(Type modelType);

--- a/src/RedArrow.Argo.Client/Session/Registry/ModelRegistry.cs
+++ b/src/RedArrow.Argo.Client/Session/Registry/ModelRegistry.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using RedArrow.Argo.Client.Extensions;
 
 namespace RedArrow.Argo.Client.Session.Registry
 {
@@ -361,30 +362,15 @@ namespace RedArrow.Argo.Client.Session.Registry
                 return default(TMeta);
             }
 
-            JToken mt;
-            var pathSegments = metaName.Split(new[] { '.' }, 2);
-            if (pathSegments.Length > 1)
+            var mt = meta.SelectToken(metaName);
+            if (mt == null)
             {
-                JToken pt;
-                if (!meta.TryGetValue(pathSegments[0], out pt))
-                {
-                    return default(TMeta);
-                }
-
-                mt = pt.SelectToken(pathSegments[1]);
+                return default(TMeta);
             }
-            else
-            {
-                if (!meta.TryGetValue(metaName, out mt))
-                {
-                    return default(TMeta);
-                }
-            }
-
             return mt.ToObject<TMeta>(JsonSerializer.CreateDefault(JsonSettings));
         }
 
-        public IDictionary<string, JToken> GetMetaValues(object model)
+        public JObject GetMetaValues(object model)
         {
             if (model == null) return null;
             var metaValues = GetMetaConfigs(model.GetType())
@@ -397,7 +383,7 @@ namespace RedArrow.Argo.Client.Session.Registry
             var result = new JObject();
             foreach (var key in metaValues.Keys)
             {
-                BuildObject(result, key, metaValues[key]);
+                result.SetMetaValue(key, metaValues[key]);
             }
 
             return result;

--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -580,7 +580,7 @@ namespace RedArrow.Argo.Client.Session
 
             JObject attrs = null;
             IDictionary<string, Relationship> rltns = null;
-            IDictionary<string, JToken> meta = null;
+            JObject meta = null;
 
             // attributes
             var modelAttributes = ModelRegistry.GetAttributeValues(model);

--- a/src/RedArrow.Argo.Client/Session/Session.cs
+++ b/src/RedArrow.Argo.Client/Session/Session.cs
@@ -82,36 +82,27 @@ namespace RedArrow.Argo.Client.Session
                 ModelRegistry.SetId(model, modelId);
             }
 
-            IDictionary<Guid, Resource> resourceIndex;
-
-            if (model != null) // map model to resource
+            // Create a new model instance if not already existing
+            if (model == null)
             {
-                if (ModelRegistry.IsManagedModel(model))
-                {
-                    throw new ManagedModelCreationException(model.GetType(), modelId);
-                }
-
-                // all unmanaged models in the object graph, including root
-                resourceIndex = ModelRegistry.IncludedModelsCreate(model)
-                    .Select(CreateModelResource)
-                    .ToDictionary(x => x.Id);
-            }
-            else // model is null - all we know is resource type
-            {
-                resourceIndex = new Dictionary<Guid, Resource>
-                {
-                    {
-                        modelId, new Resource
-                        {
-                            Id = modelId,
-                            Type = ModelRegistry.GetResourceType(rootModelType)
-                        }
-                    }
-                };
+                model = Activator.CreateInstance<TModel>();
+                ModelRegistry.SetId(model, modelId);
             }
 
-            var rootResource = resourceIndex[modelId];
-            var includes = resourceIndex.Values.Where(x => x.Id != modelId).ToArray();
+            if (ModelRegistry.IsManagedModel(model))
+            {
+                throw new ManagedModelCreationException(model.GetType(), modelId);
+            }
+
+            // all unmanaged models in the object graph, including root
+            var allModels = ModelRegistry.IncludedModelsCreate(model);
+            foreach (var newModel in allModels)
+            {
+                CreateModelResource(newModel);
+            }
+
+            var rootResource = ModelRegistry.GetResource(model);
+            var includes = allModels.Where(x => x != model).Select(ModelRegistry.GetResource).ToArray();
             if (Log.IsDebugEnabled())
             {
                 Log.Debug(() => $"preparing to POST {rootResource.Type}:{{{rootResource.Id}}}");
@@ -127,17 +118,19 @@ namespace RedArrow.Argo.Client.Session
             if (response.StatusCode == HttpStatusCode.Created)
             {
                 var root = await response.GetContentModel<ResourceRootSingle>(JsonSettings);
-                resourceIndex[modelId] = root.Data;
+                // Update the model instance in the argument
+                var initialize = rootModelType.GetInitializeMethod();
+                initialize.Invoke(model, new object[] { root.Data, this });
             }
 
             // create and cache includes
-            await Task.WhenAll(resourceIndex.Values.Select(x => Task.Run(() =>
+            await Task.WhenAll(allModels.Select(x => Task.Run(() =>
             {
-                var m = CreateResourceModel(x);
-                Cache.Update(x.Id, m);
+                var resource = ModelRegistry.GetResource(x);
+                Cache.Update(resource.Id, x);
             })));
 
-            return Cache.Retrieve<TModel>(modelId);
+            return (TModel)model;
         }
 
         public async Task Update<TModel>(TModel model)
@@ -162,11 +155,10 @@ namespace RedArrow.Argo.Client.Session
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var root = await response.GetContentModel<ResourceRootSingle>(JsonSettings);
-                if (root.Data != null)
-                {
-                    var m = CreateResourceModel(root.Data);
-                    Cache.Update(root.Data.Id, m);
-                }
+                // Update the model instance in the argument
+                var initialize = typeof(TModel).GetInitializeMethod();
+                initialize.Invoke(model, new object[] { root.Data, this });
+                Cache.Update(root.Data.Id, model);
             }
             else if (response.StatusCode == HttpStatusCode.NoContent)
             {
@@ -570,7 +562,10 @@ namespace RedArrow.Argo.Client.Session
 
             var type = ModelRegistry.GetModelType(resource.Type);
             Log.Debug(() => $"activating session-managed instance of {type.FullName}:{{{resource.Id}}}");
-            return Activator.CreateInstance(type, resource, this);
+            var model = Activator.CreateInstance(type);
+            var initialize = type.GetInitializeMethod();
+            initialize.Invoke(model, new object[] { resource, this });
+            return model;
         }
 
         public Resource CreateModelResource(object model)
@@ -603,7 +598,7 @@ namespace RedArrow.Argo.Client.Session
                 meta = modelMeta;
             }
 
-            return new Resource
+            var resource = new Resource
             {
                 Id = ModelRegistry.GetId(model),
                 Type = resourceType,
@@ -611,6 +606,10 @@ namespace RedArrow.Argo.Client.Session
                 Relationships = rltns,
                 Meta = meta
             };
+            // Update the model instance in the argument
+            var initialize = modelType.GetInitializeMethod();
+            initialize.Invoke(model, new object[] { resource, this });
+            return resource;
         }
 
         private void ThrowIfDisposed()

--- a/src/RedArrow.Argo.Fody.Shared/CtorWeaver.cs
+++ b/src/RedArrow.Argo.Fody.Shared/CtorWeaver.cs
@@ -1,89 +1,11 @@
 ﻿using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
-using RedArrow.Argo.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace RedArrow.Argo
 {
     public partial class ModuleWeaver
     {
-        private void AddCtor(ModelWeavingContext context)
-        {
-            // public Ctor(Guid id, IResourceIdentifier resource, IModelSession session)
-            // {
-            //   Id = id;
-            //   __argo__generated_Resource = resource;
-            //   __argo__generated_session = session;
-            //  }
-            var ctor = new MethodDefinition(
-                ".ctor",
-                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
-                TypeSystem.Void);
-
-            ctor.Parameters.Add(
-                new ParameterDefinition(
-                    "resource",
-                    ParameterAttributes.None,
-                    context.ImportReference(_resourceIdentifierTypeDef)));
-            ctor.Parameters.Add(
-                new ParameterDefinition(
-                    "session",
-                    ParameterAttributes.None,
-                    context.ImportReference(_sessionTypeDef)));
-
-            var objectCtor = context.ImportReference(TypeSystem.Object.Resolve().GetConstructors().First());
-
-            var idBackingField = context
-                .IdPropDef
-                ?.GetMethod
-                ?.Body
-                ?.Instructions
-                ?.SingleOrDefault(x => x.OpCode == OpCodes.Ldfld)
-                ?.Operand as FieldReference;
-            // supply generic type arguments to template
-            var sessionGetId = _session_GetId.MakeGenericMethod(context.ModelTypeDef);
-
-            var proc = ctor.Body.GetILProcessor();
-
-            // public Patient(IResourceIdentifier resource, IModelSession session)
-            // {
-            //   this.__argo__generated_Resource = resource;
-            //   this.__argo__generated_session = session;
-            //   this.__argo__generated_includePath = "model.include.path";
-            //   this.Id = __argo__generated_session.GetId<TModel>();
-            // }
-            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
-            proc.Emit(OpCodes.Call, objectCtor); // call base ctor on 'this'
-
-            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
-            proc.Emit(OpCodes.Ldarg_1); // load arg 'resource' onto stack
-            proc.Emit(OpCodes.Callvirt, context.ResourcePropDef.SetMethod);
-
-            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
-            proc.Emit(OpCodes.Ldarg_2); // load arg 'session' onto stack
-            proc.Emit(OpCodes.Stfld, context.SessionField); // this.__argo__generated_session = session;
-
-            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
-            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
-            proc.Emit(OpCodes.Ldfld, context.SessionField); // load this.__argo__generated_session
-            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
-            proc.Emit(OpCodes.Callvirt, context.ImportReference(sessionGetId));
-            proc.Emit(OpCodes.Stfld, idBackingField); // this.<Id>K_backingField = this.__argo__generated_session.GetId<TModel>();
-
-            // this._attrBackingField = this.__argo__generated_session.GetAttribute
-            WeaveAttributeFieldInitializers(context, proc, context.MappedAttributes);
-
-            // this._attrBackingField = this.__argo__generated_session.GetMeta
-            WeaveMetaFieldInitializers(context, proc, context.MappedMeta);
-
-            proc.Emit(OpCodes.Ret); // return
-
-            context.Methods.Add(ctor);
-        }
-
         private void AddStaticCtor(ModelWeavingContext context)
         {
             var ctor = context.ModelTypeDef.GetStaticConstructor();
@@ -119,83 +41,6 @@ namespace RedArrow.Argo
             }
 
             context.ModelTypeDef.IsBeforeFieldInit = false;
-        }
-
-        private void WeaveAttributeFieldInitializers(
-            ModelWeavingContext context,
-            ILProcessor proc,
-            IEnumerable<PropertyDefinition> attrPropDefs)
-        {
-            foreach (var attrPropDef in attrPropDefs)
-            {
-                // supply generic type arguments to template
-                var sessionGetAttr = _session_GetAttribute
-                    .MakeGenericMethod(context.ModelTypeDef, attrPropDef.PropertyType);
-
-                var backingField = attrPropDef.BackingField();
-
-                if (backingField == null)
-                {
-                    throw new Exception($"Failed to load backing field for property {attrPropDef?.FullName}");
-                }
-
-                var propAttr = attrPropDef.CustomAttributes.GetAttribute(Constants.Attributes.Property);
-                var attrName = propAttr.ConstructorArguments
-                                   .Select(x => x.Value as string)
-                                   .SingleOrDefault() ?? attrPropDef.Name.Camelize();
-
-                proc.Emit(OpCodes.Ldarg_0);
-
-                proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack to reference session field
-                proc.Emit(OpCodes.Ldfld, context.SessionField); // load __argo__generated_session field from 'this'
-                proc.Emit(OpCodes.Ldarg_0); // load 'this'
-                proc.Emit(OpCodes.Ldstr, attrName); // load attrName onto stack
-                proc.Emit(OpCodes.Callvirt, context.ImportReference(
-                    sessionGetAttr,
-                    attrPropDef.PropertyType.IsGenericParameter
-                        ? context.ModelTypeDef
-                        : null)); // invoke session.GetAttribute(..)
-
-                proc.Emit(OpCodes.Stfld, backingField); // store return value in 'this'.<backing field>
-            }
-        }
-
-        private void WeaveMetaFieldInitializers(
-            ModelWeavingContext context,
-            ILProcessor proc,
-            IEnumerable<PropertyDefinition> metaPropDefs)
-        {
-            foreach (var def in metaPropDefs)
-            {
-                // supply generic type arguments to template
-                var sessionGetAttr = _session_GetMeta.MakeGenericMethod(context.ModelTypeDef, def.PropertyType);
-
-                var backingField = def.BackingField();
-
-                if (backingField == null)
-                {
-                    throw new Exception($"Failed to load backing field for property {def?.FullName}");
-                }
-
-                var propAttr = def.CustomAttributes.GetAttribute(Constants.Attributes.Meta);
-                var metaName = propAttr.ConstructorArguments
-                                   .Select(x => x.Value as string)
-                                   .SingleOrDefault() ?? def.Name.Camelize();
-
-                proc.Emit(OpCodes.Ldarg_0);
-
-                proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack to reference session field
-                proc.Emit(OpCodes.Ldfld, context.SessionField); // load __argo__generated_session field from 'this'
-                proc.Emit(OpCodes.Ldarg_0); // load 'this'
-                proc.Emit(OpCodes.Ldstr, metaName); // load attrName onto stack
-                proc.Emit(OpCodes.Callvirt, context.ImportReference(
-                    sessionGetAttr,
-                    def.PropertyType.IsGenericParameter
-                        ? context.ModelTypeDef
-                        : null)); // invoke session.GetMeta(..)
-
-                proc.Emit(OpCodes.Stfld, backingField); // store return value in 'this'.<backing field>
-            }
         }
     }
 }

--- a/src/RedArrow.Argo.Fody.Shared/InitializeWeaver.cs
+++ b/src/RedArrow.Argo.Fody.Shared/InitializeWeaver.cs
@@ -1,0 +1,152 @@
+﻿using Mono.Cecil;
+using Mono.Cecil.Cil;
+using RedArrow.Argo.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RedArrow.Argo
+{
+    public partial class ModuleWeaver
+    {
+        private void AddInitialize(ModelWeavingContext context)
+        {
+            // public void __argo__generated_Initialize(IResourceIdentifier resource, IModelSession session)
+            // {
+            //   this.__argo__generated_Resource = resource;
+            //   this.__argo__generated_session = session;
+            //   this.__argo__generated_includePath = "model.include.path";
+            //   this.Id = __argo__generated_session.GetId<TModel>();
+            //  }
+            var initialize = new MethodDefinition(
+                "__argo__generated_Initialize",
+                MethodAttributes.Public,
+                TypeSystem.Void);
+
+            initialize.Parameters.Add(
+                new ParameterDefinition(
+                    "resource",
+                    ParameterAttributes.None,
+                    context.ImportReference(_resourceIdentifierTypeDef)));
+            initialize.Parameters.Add(
+                new ParameterDefinition(
+                    "session",
+                    ParameterAttributes.None,
+                    context.ImportReference(_sessionTypeDef)));
+
+            var idBackingField = context
+                .IdPropDef
+                ?.GetMethod
+                ?.Body
+                ?.Instructions
+                ?.SingleOrDefault(x => x.OpCode == OpCodes.Ldfld)
+                ?.Operand as FieldReference;
+            // supply generic type arguments to template
+            var sessionGetId = _session_GetId.MakeGenericMethod(context.ModelTypeDef);
+
+            var proc = initialize.Body.GetILProcessor();
+
+            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
+            proc.Emit(OpCodes.Ldarg_1); // load arg 'resource' onto stack
+            proc.Emit(OpCodes.Callvirt, context.ResourcePropDef.SetMethod);
+
+            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
+            proc.Emit(OpCodes.Ldarg_2); // load arg 'session' onto stack
+            proc.Emit(OpCodes.Stfld, context.SessionField); // this.__argo__generated_session = session;
+
+            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
+            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
+            proc.Emit(OpCodes.Ldfld, context.SessionField); // load this.__argo__generated_session
+            proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack
+            proc.Emit(OpCodes.Callvirt, context.ImportReference(sessionGetId));
+            proc.Emit(OpCodes.Stfld, idBackingField); // this.<Id>K_backingField = this.__argo__generated_session.GetId<TModel>();
+
+            // this._attrBackingField = this.__argo__generated_session.GetAttribute
+            WeaveAttributeFieldInitializers(context, proc, context.MappedAttributes);
+
+            // this._attrBackingField = this.__argo__generated_session.GetMeta
+            WeaveMetaFieldInitializers(context, proc, context.MappedMeta);
+
+            proc.Emit(OpCodes.Ret); // return
+
+            context.Methods.Add(initialize);
+        }
+
+        private void WeaveAttributeFieldInitializers(
+            ModelWeavingContext context,
+            ILProcessor proc,
+            IEnumerable<PropertyDefinition> attrPropDefs)
+        {
+            foreach (var attrPropDef in attrPropDefs)
+            {
+                // supply generic type arguments to template
+                var sessionGetAttr = _session_GetAttribute
+                    .MakeGenericMethod(context.ModelTypeDef, attrPropDef.PropertyType);
+
+                var backingField = attrPropDef.BackingField();
+
+                if (backingField == null)
+                {
+                    throw new Exception($"Failed to load backing field for property {attrPropDef?.FullName}");
+                }
+
+                var propAttr = attrPropDef.CustomAttributes.GetAttribute(Constants.Attributes.Property);
+                var attrName = propAttr.ConstructorArguments
+                                   .Select(x => x.Value as string)
+                                   .SingleOrDefault() ?? attrPropDef.Name.Camelize();
+
+                proc.Emit(OpCodes.Ldarg_0);
+
+                proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack to reference session field
+                proc.Emit(OpCodes.Ldfld, context.SessionField); // load __argo__generated_session field from 'this'
+                proc.Emit(OpCodes.Ldarg_0); // load 'this'
+                proc.Emit(OpCodes.Ldstr, attrName); // load attrName onto stack
+                proc.Emit(OpCodes.Callvirt, context.ImportReference(
+                    sessionGetAttr,
+                    attrPropDef.PropertyType.IsGenericParameter
+                        ? context.ModelTypeDef
+                        : null)); // invoke session.GetAttribute(..)
+
+                proc.Emit(OpCodes.Stfld, backingField); // store return value in 'this'.<backing field>
+            }
+        }
+
+        private void WeaveMetaFieldInitializers(
+            ModelWeavingContext context,
+            ILProcessor proc,
+            IEnumerable<PropertyDefinition> metaPropDefs)
+        {
+            foreach (var def in metaPropDefs)
+            {
+                // supply generic type arguments to template
+                var sessionGetAttr = _session_GetMeta.MakeGenericMethod(context.ModelTypeDef, def.PropertyType);
+
+                var backingField = def.BackingField();
+
+                if (backingField == null)
+                {
+                    throw new Exception($"Failed to load backing field for property {def?.FullName}");
+                }
+
+                var propAttr = def.CustomAttributes.GetAttribute(Constants.Attributes.Meta);
+                var metaName = propAttr.ConstructorArguments
+                                   .Select(x => x.Value as string)
+                                   .SingleOrDefault() ?? def.Name.Camelize();
+
+                proc.Emit(OpCodes.Ldarg_0);
+
+                proc.Emit(OpCodes.Ldarg_0); // load 'this' onto stack to reference session field
+                proc.Emit(OpCodes.Ldfld, context.SessionField); // load __argo__generated_session field from 'this'
+                proc.Emit(OpCodes.Ldarg_0); // load 'this'
+                proc.Emit(OpCodes.Ldstr, metaName); // load attrName onto stack
+                proc.Emit(OpCodes.Callvirt, context.ImportReference(
+                    sessionGetAttr,
+                    def.PropertyType.IsGenericParameter
+                        ? context.ModelTypeDef
+                        : null)); // invoke session.GetMeta(..)
+
+                proc.Emit(OpCodes.Stfld, backingField); // store return value in 'this'.<backing field>
+            }
+        }
+    }
+}

--- a/src/RedArrow.Argo.Fody.Shared/ModuleWeaver.cs
+++ b/src/RedArrow.Argo.Fody.Shared/ModuleWeaver.cs
@@ -101,7 +101,7 @@ namespace RedArrow.Argo
                 {
                     AddResourceIdentifierProperty(context);
                     AddPatchProperty(context);
-                    AddCtor(context);
+                    AddInitialize(context);
                     AddStaticCtor(context);
                     WeaveAttributes(context);
                     WeaveMeta(context);

--- a/src/RedArrow.Argo.Fody.Shared/RedArrow.Argo.Fody.Shared.projitems
+++ b/src/RedArrow.Argo.Fody.Shared/RedArrow.Argo.Fody.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TypeDefinitionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HasManyIdsWeaver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HasOneIdWeaver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)InitializeWeaver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MetaWeaver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AttributeWeaver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IncludeWeaver.cs" />

--- a/src/RedArrow.Argo.TestUtils/EtagRequestModifier.cs
+++ b/src/RedArrow.Argo.TestUtils/EtagRequestModifier.cs
@@ -12,11 +12,12 @@ namespace RedArrow.Argo.TestUtils
         private const string EtagMetaPath = "system.eTag";
         public override void UpdateResource(HttpRequestMessage request, Resource originalResource, ResourceRootSingle patch)
         {
-            var eTag = originalResource.GetMeta().SelectToken(EtagMetaPath)
+            // First check patch then check the original resource
+            var eTag = patch.Data.GetMeta().SelectToken(EtagMetaPath)
                 ?? originalResource.GetMeta().SelectToken(EtagMetaPath);
             if (eTag != null)
             {
-                request.Headers.IfMatch.Add(new EntityTagHeaderValue(eTag.ToString()));
+                request.Headers.IfMatch.Add(GetEtagHeader(eTag.ToString()));
             }
         }
 
@@ -24,6 +25,16 @@ namespace RedArrow.Argo.TestUtils
         {
             // Delete anything
             request.Headers.IfMatch.Add(EntityTagHeaderValue.Any);
+        }
+
+        private EntityTagHeaderValue GetEtagHeader(string value)
+        {
+            // Etag header will not parse *
+            if (value == EntityTagHeaderValue.Any.Tag)
+            {
+                return EntityTagHeaderValue.Any;
+            }
+            return new EntityTagHeaderValue(value);
         }
     }
 }

--- a/src/RedArrow.Argo.TestUtils/EtagRequestModifier.cs
+++ b/src/RedArrow.Argo.TestUtils/EtagRequestModifier.cs
@@ -9,13 +9,14 @@ namespace RedArrow.Argo.TestUtils
 {
     public class EtagRequestModifier : HttpRequestModifier
     {
-        public override void UpdateResource(HttpRequestMessage request, Resource resource, ResourceRootSingle patch)
+        private const string EtagMetaPath = "system.eTag";
+        public override void UpdateResource(HttpRequestMessage request, Resource originalResource, ResourceRootSingle patch)
         {
-            resource.GetMeta().TryGetValue("system", out var system);
-            var eTag = system?.Value<string>("eTag");
+            var eTag = originalResource.GetMeta().SelectToken(EtagMetaPath)
+                ?? originalResource.GetMeta().SelectToken(EtagMetaPath);
             if (eTag != null)
             {
-                request.Headers.IfMatch.Add(new EntityTagHeaderValue(eTag));
+                request.Headers.IfMatch.Add(new EntityTagHeaderValue(eTag.ToString()));
             }
         }
 

--- a/src/WovenByFody/ComplexModel.cs
+++ b/src/WovenByFody/ComplexModel.cs
@@ -26,6 +26,6 @@ namespace WovenByFody
         public IEnumerable<Guid> BasicModelIds { get; }
 
         [HasMany]
-        public IEnumerable<BasicModel> BasicModels { get; set; }
+        public ICollection<BasicModel> BasicModels { get; set; }
     }
 }

--- a/src/WovenByFody/Patient.cs
+++ b/src/WovenByFody/Patient.cs
@@ -32,5 +32,8 @@ namespace WovenByFody
 
         [Meta]
         public string Version { get; set; }
+
+        [Meta("system.eTag")]
+        public string Etag { get; set; }
     }
 }

--- a/src/WovenByFody/Patient.cs
+++ b/src/WovenByFody/Patient.cs
@@ -28,6 +28,9 @@ namespace WovenByFody
         public Company Insurance { get; set; }
 
         [Meta]
+        public DateTime ContactTime { get; set; }
+
+        [Meta("system.createdAt")]
         public DateTime Created { get; set; }
 
         [Meta]
@@ -35,5 +38,8 @@ namespace WovenByFody
 
         [Meta("system.eTag")]
         public string Etag { get; set; }
+
+        [Meta("system.updatedAt")]
+        public DateTime UpdatedAt { get; set; }
     }
 }


### PR DESCRIPTION
#76 Convert Meta from Dictionary to JObject to make the Patch object consistent and allow more flexible Meta pathing.