### PR TITLE
 Making attribute and meta setters null safe

### DIFF
--- a/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
@@ -133,5 +133,45 @@ namespace RedArrow.Argo.Client.Integration.Session
                 await session.Delete<Patient>(crossSessionId);
             }
         }
+
+        [Fact, Trait("Category", "Integration")]
+        public async Task SetAttributesNullPatient()
+        {
+            Guid crossSessionId;
+
+            using (var session = SessionFactory.CreateSession())
+            {
+                var patient = new Patient
+                {
+                    FirstName = "Original",
+                    LastName = "Name"
+                };
+
+                patient = await session.Create(patient);
+
+                patient.FirstName = null;
+                patient.LastName = null;
+                patient.Version = null;
+
+                await session.Update(patient);
+
+                crossSessionId = patient.Id;
+            }
+            using (var session = SessionFactory.CreateSession())
+            {
+                var patient = await session.Get<Patient>(crossSessionId);
+
+                Assert.Equal(crossSessionId, patient.Id);
+                
+                Assert.Null(patient.FirstName);
+                Assert.Null(patient.LastName);
+                Assert.Null(patient.Version);
+            }
+            // cleanup
+            using (var session = SessionFactory.CreateSession())
+            {
+                await session.Delete<Patient>(crossSessionId);
+            }
+        }
     }
 }

--- a/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
@@ -144,7 +144,8 @@ namespace RedArrow.Argo.Client.Integration.Session
                 var patient = new Patient
                 {
                     FirstName = "Original",
-                    LastName = "Name"
+                    LastName = "Name",
+                    Version = "1"
                 };
 
                 patient = await session.Create(patient);

--- a/src/RedArrow.Argo.Client/Extensions/JObjectExtensions.cs
+++ b/src/RedArrow.Argo.Client/Extensions/JObjectExtensions.cs
@@ -27,7 +27,7 @@ namespace RedArrow.Argo.Client.Extensions
             }
             // Set the Meta at the terminal node
             var lastSegment = path[path.Length - 1];
-            nextMeta[lastSegment] = JToken.FromObject(value);
+            nextMeta[lastSegment] = value == null ? JValue.CreateNull() : JToken.FromObject(value);
         }
     }
 }

--- a/src/RedArrow.Argo.Client/Model/Resource.cs
+++ b/src/RedArrow.Argo.Client/Model/Resource.cs
@@ -42,7 +42,7 @@ namespace RedArrow.Argo.Client.Model
 
         public void SetAttribute(string attrName, object value)
         {
-            GetAttributes()[attrName] = JToken.FromObject(value);
+            GetAttributes()[attrName] = value == null ? JValue.CreateNull() : JToken.FromObject(value);
         }
 
         public IDictionary<string, Relationship> GetRelationships()

--- a/src/RedArrow.Argo.Client/Session/Registry/ModelRegistry.cs
+++ b/src/RedArrow.Argo.Client/Session/Registry/ModelRegistry.cs
@@ -419,7 +419,7 @@ namespace RedArrow.Argo.Client.Session.Registry
             }
             else
             {
-                token[name] = JToken.FromObject(value);
+                token[name] = value == null ? JValue.CreateNull() : JToken.FromObject(value);
             }
         }
     }


### PR DESCRIPTION
#80 Fixing issue where setting an attribute to null on a managed object would cause an exception in Resource